### PR TITLE
fix implicit int for GCC 14

### DIFF
--- a/src/exec.c
+++ b/src/exec.c
@@ -463,7 +463,7 @@ const EXEC_INSTRUCTION_INFO *OPBuf_getentry(int no)
     戻り値：
       なし。
 */
-void OPBuf_display(n)
+void OPBuf_display(int n)
 {
     int max = OPBuf_numentries();
     int i;


### PR DESCRIPTION
-Werror=implicit-int is now enabled by default.

This can also be worked around by passing -fpermissive to the compiler.
https://gcc.gnu.org/gcc-14/porting_to.html